### PR TITLE
LzmaSpec: add capability to emit KKP files

### DIFF
--- a/contrib/parsemap.py
+++ b/contrib/parsemap.py
@@ -109,7 +109,7 @@ def main(opts):
         totalww+= x.wwgt
     print("-"*79)
     print("Total:%33d\t\t%10.2f\t%14.1f%%" % (totals, totalw, 100*totalw/totals))
- 
+
     return 0
 
 if __name__ == '__main__':
@@ -130,5 +130,5 @@ map file. (`ld -Map', `cc -Wl,-Map', see respective manpages.)
     p.add_argument("--lzmaspec", type=str, default="./LzmaSpec", \
                    help="LzmaSpec binary to use (default: ./LzmaSpec)")
 
-    exit(main(p.parse_args(sys.argv[1:])))
+    exit(main(p.parse_args()))
 


### PR DESCRIPTION
KKP files contain statistical information on which bytes in a file compress better or worse. They are emitted by several tools (e.g. forks of kkrunchy and Crinkler) and can be viewed using e.g. https://github.com/ConspiracyHu/kkpView-public (see also https://github.com/ConspiracyHu/kkpView-public/pull/1 ).

I'll add more detailed analysis stats (wrt contrib/parsemap.py etc) later.